### PR TITLE
add Haskell blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@
 
 - [J. De Goes](http://degoes.net/)
 
-- [Runar](http://blog.higher-order.com/)
+- [Runar](http://blog.higher-order.com/) [old](https://apocalisp.wordpress.com/)
 
 - [Habla](https://blog.hablapps.com/)
 
@@ -217,6 +217,18 @@
 - [Kubuszok](https://kubuszok.com/#blog)
 
 - [FP Complete](https://www.fpcomplete.com/blog)
+    - Haskell
+
+- [Edward Kmett](http://comonad.com/reader/)
+    - Haskell
+
+-  [Dan Piponi](http://blog.sigfpe.com/)
+    - Haskell
+
+- [Phil Freeman](https://blog.functorial.com/)
+    - Haskell/Purescript
+
+- [Russell O’Connor](http://r6.ca/blog/)
     - Haskell
 
 - [Mine ! :D](https://github.com/mmenestret/fp-ressources/)


### PR DESCRIPTION
- Phil Freeman has a lot of great and innovative posts (and video presentations) about comonads and day convolution (he focus on Purescript that is Haskell in JavaScript), he have nice talk about Profunctors
- Edward Kmett - he is the guy who, single handed, written all libraries about CT in Haskell, Cats/Scalaz are just translations of the simplests of them, his blog covers most complicated things Kan extensions, recursion schemas etc, he streams lots and lots of videos (there are few in Scala about Lens in Scala)
- Dan Pipponi - a lot of awesome blog posts there, many things done by EK are inspired by posts by DP
- Russell O’Connor - do not blog much but when he do, people do conference talks about it :) and there is famous Functor Oriented Programming there

+ old blog by Runar - there are IO Monad, State Monad and typelevel programming a'la shapeless - great stuff :)